### PR TITLE
Pawn moving

### DIFF
--- a/FiaMedKnuff/FiaGame/Game.cs
+++ b/FiaMedKnuff/FiaGame/Game.cs
@@ -7,7 +7,8 @@ using System.Threading.Tasks;
 namespace FiaMedKnuff.FiaGame {
     class Game {
 
-        //public Dictionary<SpaceType, Dictionary<int, TileControl>> Spaces = new Dictionary<SpaceType, Dictionary<int, TileControl>>();
+        public static int Spaces = 40;
+
         public Dictionary<SpaceType, Dictionary<int, Tile>> Tiles = new Dictionary<SpaceType, Dictionary<int, Tile>>();
 
         /// <summary>
@@ -15,10 +16,21 @@ namespace FiaMedKnuff.FiaGame {
         /// </summary>
         public int Turn = 0;
 
-
+        public Team[] Teams = new Team[] {
+            new Team(Tile.TeamColor.Red, Team.TeamType.Player)
+        };
+        public int CurrentTeamIndex = 0;
+        public Team CurrentTeam => Teams[CurrentTeamIndex];
 
         public enum GameState {
+            /// <summary>
+            /// Before the player has clicked the die.
+            /// </summary>
             PreRoll,
+            /// <summary>
+            /// The state that generates possible choices after the player rolling the die.
+            /// </summary>
+            PostRoll
         }
 
         public Game() {

--- a/FiaMedKnuff/FiaGame/Game.cs
+++ b/FiaMedKnuff/FiaGame/Game.cs
@@ -17,7 +17,7 @@ namespace FiaMedKnuff.FiaGame {
         public int Turn = 0;
 
         public Team[] Teams = new Team[] {
-            new Team(Tile.TeamColor.Red, Team.TeamType.Player)
+            new Team(TeamColor.Red, Team.TeamType.Player)
         };
         public int CurrentTeamIndex = 0;
         public Team CurrentTeam => Teams[CurrentTeamIndex];
@@ -47,7 +47,7 @@ namespace FiaMedKnuff.FiaGame {
 
             // Create each tile class so that a TileControl can register itself to it after loading
             var homeTiles = new Dictionary<int, Tile>();
-            Tile.TeamColor[] teams = { Tile.TeamColor.Red, Tile.TeamColor.Yellow, Tile.TeamColor.Green, Tile.TeamColor.Blue };
+            TeamColor[] teams = { TeamColor.Red, TeamColor.Yellow, TeamColor.Green, TeamColor.Blue };
             for (int i = 0; i < 4; i++) {
                 for (int j = 0; j < 4; j++) {
                     var team = teams[i];
@@ -85,4 +85,5 @@ namespace FiaMedKnuff.FiaGame {
     public enum SpaceType {
         Home, TowardsCenter, Surrounding, Center
     }
+
 }

--- a/FiaMedKnuff/FiaGame/Game.cs
+++ b/FiaMedKnuff/FiaGame/Game.cs
@@ -35,7 +35,7 @@ namespace FiaMedKnuff.FiaGame {
 
             // Create each tile class so that a TileControl can register itself to it after loading
             var homeTiles = new Dictionary<int, Tile>();
-            Tile.TileState[] teams = { Tile.TileState.Red, Tile.TileState.Yellow, Tile.TileState.Green, Tile.TileState.Blue };
+            Tile.TeamColor[] teams = { Tile.TeamColor.Red, Tile.TeamColor.Yellow, Tile.TeamColor.Green, Tile.TeamColor.Blue };
             for (int i = 0; i < 4; i++) {
                 for (int j = 0; j < 4; j++) {
                     var team = teams[i];
@@ -43,7 +43,6 @@ namespace FiaMedKnuff.FiaGame {
 
                     // Create the tile...
                     var tile = new Tile(space);
-                    tile.State = team;
                     homeTiles.Add(space, tile);
 
                     // ...Create the pawn

--- a/FiaMedKnuff/FiaGame/Game.cs
+++ b/FiaMedKnuff/FiaGame/Game.cs
@@ -10,11 +10,25 @@ namespace FiaMedKnuff.FiaGame {
         //public Dictionary<SpaceType, Dictionary<int, TileControl>> Spaces = new Dictionary<SpaceType, Dictionary<int, TileControl>>();
         public Dictionary<SpaceType, Dictionary<int, Tile>> Tiles = new Dictionary<SpaceType, Dictionary<int, Tile>>();
 
-        public Game() {
+        /// <summary>
+        /// The current turn of the game. Increments by the end of the turn.
+        /// </summary>
+        public int Turn = 0;
 
+
+
+        public enum GameState {
+            PreRoll,
+        }
+
+        public Game() {
+            // TODO: When it is time, register tiles and players here instead.
         }
 
         private bool HasRegistered = false;
+        /// <summary>
+        /// Fills the Tiles dictionary with tiles and puts pawns into each home
+        /// </summary>
         public void RegisterTiles() {
             if (HasRegistered) return;
             HasRegistered = true;
@@ -27,9 +41,13 @@ namespace FiaMedKnuff.FiaGame {
                     var team = teams[i];
                     var space = i * 4 + j;
 
+                    // Create the tile...
                     var tile = new Tile(space);
                     tile.State = team;
                     homeTiles.Add(space, tile);
+
+                    // ...Create the pawn
+                    var pawn = new Pawn(team, tile);
                 }
                 
             }

--- a/FiaMedKnuff/FiaGame/GameEvents.cs
+++ b/FiaMedKnuff/FiaGame/GameEvents.cs
@@ -9,6 +9,11 @@ namespace FiaMedKnuff.FiaGame {
     internal static class GameEvents {
         public static void OnTileClicked(Tile tile) {
             Trace.WriteLine($"Boop! You have clicked tile with space {tile.Space}!");
+            tile.Stander?.Move(1); // Move the stander if it exists
+        }
+
+        public static void OnDieClicked() {
+            throw new NotImplementedException();
         }
     }
 }

--- a/FiaMedKnuff/FiaGame/GameEvents.cs
+++ b/FiaMedKnuff/FiaGame/GameEvents.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FiaMedKnuff.FiaGame {
+    internal static class GameEvents {
+        public static void OnTileClicked(Tile tile) {
+            Trace.WriteLine($"Boop! You have clicked tile with space {tile.Space}!");
+        }
+    }
+}

--- a/FiaMedKnuff/FiaGame/Pawn.cs
+++ b/FiaMedKnuff/FiaGame/Pawn.cs
@@ -3,9 +3,17 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using static FiaMedKnuff.FiaGame.Tile;
 
 namespace FiaMedKnuff.FiaGame {
+
+    public enum TeamColor {
+        None,
+        Red,
+        Green,
+        Blue,
+        Yellow,
+    }
+
     internal class Pawn {
 
         public TeamColor Team;

--- a/FiaMedKnuff/FiaGame/Pawn.cs
+++ b/FiaMedKnuff/FiaGame/Pawn.cs
@@ -8,15 +8,16 @@ using static FiaMedKnuff.FiaGame.Tile;
 namespace FiaMedKnuff.FiaGame {
     internal class Pawn {
 
-        public TileState Team;
+        public TeamColor Team;
 
         public Tile CurrentTile;
         public int Space => CurrentTile.Space;
 
         public Pawn() { }
 
-        public Pawn(TileState team, Tile currentTile) {
+        public Pawn(TeamColor team, Tile currentTile) {
             this.Team = team; this.CurrentTile = currentTile;
+            currentTile.Stander = this;
         }
 
         public void Move(int spaces) {

--- a/FiaMedKnuff/FiaGame/Pawn.cs
+++ b/FiaMedKnuff/FiaGame/Pawn.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using static FiaMedKnuff.FiaGame.Tile;
+
+namespace FiaMedKnuff.FiaGame {
+    internal class Pawn {
+
+        public TileState Team;
+
+        public Tile CurrentTile;
+        public int Space => CurrentTile.Space;
+
+        public Pawn() { }
+
+        public Pawn(TileState team, Tile currentTile) {
+            this.Team = team; this.CurrentTile = currentTile;
+        }
+
+        public void Move(int spaces) {
+            Tile from = CurrentTile;
+            // Temporary code
+            Tile to = GameManager.CurrentGame.Tiles[SpaceType.Surrounding][from.Space + spaces];
+            
+        }
+
+    }
+}

--- a/FiaMedKnuff/FiaGame/Pawn.cs
+++ b/FiaMedKnuff/FiaGame/Pawn.cs
@@ -20,11 +20,29 @@ namespace FiaMedKnuff.FiaGame {
             currentTile.Stander = this;
         }
 
-        public void Move(int spaces) {
+        /// <summary>
+        /// Move self from one tile to the other and refresh both tiles.
+        /// </summary>
+        /// <param name="to">Tile to move to</param>
+        public void Move(Tile to) {
             Tile from = CurrentTile;
-            // Temporary code
-            Tile to = GameManager.CurrentGame.Tiles[SpaceType.Surrounding][from.Space + spaces];
-            
+            from.Stander = null; to.Stander = this;
+            CurrentTile = to;
+            from.Refresh(); to.Refresh();
+        }
+
+        /// <summary>
+        /// Move self forwards an amount of spaces
+        /// </summary>
+        /// <param name="spaces">Spaces to move forwards</param>
+        public void Move(int spaces) {
+            // Mostly temporary code to prove it works
+            if (CurrentTile.SpaceType == SpaceType.Home) {
+                Move(GameManager.CurrentGame.Tiles[SpaceType.Surrounding][2]);
+            } else {
+                Tile to = GameManager.CurrentGame.Tiles[SpaceType.Surrounding][(CurrentTile.Space + spaces) % Game.Spaces];
+                Move(to);
+            }
         }
 
     }

--- a/FiaMedKnuff/FiaGame/Team.cs
+++ b/FiaMedKnuff/FiaGame/Team.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using static FiaMedKnuff.FiaGame.Tile;
+
+namespace FiaMedKnuff.FiaGame {
+    internal class Team {
+        public TeamColor TeamColor = TeamColor.None;
+        public enum TeamType {
+            Player, Bot
+        }
+        public TeamType Type = TeamType.Bot;
+
+        public Team() { }
+
+        public Team(TeamColor color, TeamType type) {
+
+        }
+    }
+}

--- a/FiaMedKnuff/FiaGame/Team.cs
+++ b/FiaMedKnuff/FiaGame/Team.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using static FiaMedKnuff.FiaGame.Tile;
 
 namespace FiaMedKnuff.FiaGame {
     internal class Team {

--- a/FiaMedKnuff/FiaGame/Tile.cs
+++ b/FiaMedKnuff/FiaGame/Tile.cs
@@ -10,14 +10,19 @@ namespace FiaMedKnuff.FiaGame {
     internal class Tile {
 
         public TileControl TileControl;
-        public enum TileState { 
+        public enum TeamColor { 
             None,
             Red,
             Green,
             Blue,
             Yellow,
         }
-        public TileState State = TileState.None;
+
+        /// <summary>
+        /// The Pawn that is standing on this tile.
+        /// Remember that this is updated manually.
+        /// </summary>
+        public Pawn Stander;
 
         public SpaceType SpaceType => TileControl.SpaceType;
 
@@ -32,31 +37,31 @@ namespace FiaMedKnuff.FiaGame {
         }
 
         /// <summary>
-        /// Updates the image of the tile to set state
+        /// Refreshes the tile's pawn texture depending on who is standing on it
         /// </summary>
         /// <param name="state"></param>
-        public void Update(TileState state) {
-            State = state;
-            switch (State) {
-                case TileState.None:
+        public void Refresh() {
+            TeamColor state = Stander?.Team ?? TeamColor.None;
+            switch (state) {
+                case TeamColor.None:
                     TileControl.ImageVisibility = Collapsed;
                     break;
-                case TileState.Red:
+                case TeamColor.Red:
                     TileControl.ImageVisibility = Visible;
                     TileControl.ImageSource = "/Assets/Pawns/RedPawn.png";
 
                     break;
-                case TileState.Green:
+                case TeamColor.Green:
                     TileControl.ImageVisibility = Visible;
                     TileControl.ImageSource = "/Assets/Pawns/GreenPawn.png";
 
                     break;
-                case TileState.Blue:
+                case TeamColor.Blue:
                     TileControl.ImageVisibility = Visible;
                     TileControl.ImageSource = "/Assets/Pawns/BluePawn.png";
 
                     break;
-                case TileState.Yellow:
+                case TeamColor.Yellow:
                     TileControl.ImageVisibility = Visible;
                     TileControl.ImageSource = "/Assets/Pawns/YellowPawn.png";
 

--- a/FiaMedKnuff/FiaGame/Tile.cs
+++ b/FiaMedKnuff/FiaGame/Tile.cs
@@ -10,13 +10,6 @@ namespace FiaMedKnuff.FiaGame {
     internal class Tile {
 
         public TileControl TileControl;
-        public enum TeamColor { 
-            None,
-            Red,
-            Green,
-            Blue,
-            Yellow,
-        }
 
         /// <summary>
         /// The Pawn that is standing on this tile.

--- a/FiaMedKnuff/FiaGame/Tile.cs
+++ b/FiaMedKnuff/FiaGame/Tile.cs
@@ -19,6 +19,8 @@ namespace FiaMedKnuff.FiaGame {
         }
         public TileState State = TileState.None;
 
+        public SpaceType SpaceType => TileControl.SpaceType;
+
         public int Space = -1;
 
         public Tile() {

--- a/FiaMedKnuff/FiaGame/Tile.cs
+++ b/FiaMedKnuff/FiaGame/Tile.cs
@@ -67,6 +67,8 @@ namespace FiaMedKnuff.FiaGame {
 
                     break;
             }
+            // Not sure if this should be here, but it is a good way to ensure that there are no left-over selectables...
+            // TileControl.Selectable = false;
 
         }
 

--- a/FiaMedKnuff/FiaMedKnuff.csproj
+++ b/FiaMedKnuff/FiaMedKnuff.csproj
@@ -120,6 +120,7 @@
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>
     <Compile Include="FiaGame\Game.cs" />
+    <Compile Include="FiaGame\Pawn.cs" />
     <Compile Include="FiaGame\Tile.cs" />
     <Compile Include="GamePage.xaml.cs">
       <DependentUpon>GamePage.xaml</DependentUpon>

--- a/FiaMedKnuff/FiaMedKnuff.csproj
+++ b/FiaMedKnuff/FiaMedKnuff.csproj
@@ -119,6 +119,7 @@
     <Compile Include="App.xaml.cs">
       <DependentUpon>App.xaml</DependentUpon>
     </Compile>
+    <Compile Include="FiaGame\GameEvents.cs" />
     <Compile Include="FiaGame\Game.cs" />
     <Compile Include="FiaGame\Pawn.cs" />
     <Compile Include="FiaGame\Tile.cs" />

--- a/FiaMedKnuff/FiaMedKnuff.csproj
+++ b/FiaMedKnuff/FiaMedKnuff.csproj
@@ -122,6 +122,7 @@
     <Compile Include="FiaGame\GameEvents.cs" />
     <Compile Include="FiaGame\Game.cs" />
     <Compile Include="FiaGame\Pawn.cs" />
+    <Compile Include="FiaGame\Team.cs" />
     <Compile Include="FiaGame\Tile.cs" />
     <Compile Include="GamePage.xaml.cs">
       <DependentUpon>GamePage.xaml</DependentUpon>

--- a/FiaMedKnuff/TileControl.xaml
+++ b/FiaMedKnuff/TileControl.xaml
@@ -10,7 +10,18 @@
     d:DesignWidth="64"
     Loaded="UserControl_Loaded">
 
-    <Border Style="{StaticResource TileBorder}" Background="{x:Bind BackgroundColor, Mode=OneWay}" Margin="2">
-        <Image Source="{x:Bind ImageSource, Mode=OneWay}" Visibility="{x:Bind ImageVisibility, Mode=OneWay}"/>
+    <!-- Properties:
+            - BackgroundColor,
+            - ImageSource,
+            - ImageVisibility
+    -->
+    <Border Style="{StaticResource TileBorder}"
+            Background="{x:Bind BackgroundColor, Mode=OneWay}"
+            Margin="2"
+            Tapped="Border_Tapped"
+            PointerEntered="Border_PointerEntered"
+            PointerExited="Border_PointerExited">
+        <Image Source="{x:Bind ImageSource, Mode=OneWay}"
+               Visibility="{x:Bind ImageVisibility, Mode=OneWay}"/>
     </Border>
 </UserControl>

--- a/FiaMedKnuff/TileControl.xaml.cs
+++ b/FiaMedKnuff/TileControl.xaml.cs
@@ -15,6 +15,7 @@ using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Navigation;
 using FiaMedKnuff.FiaGame;
+using Windows.UI.Core;
 
 // Denna klass använder för tillfället kod genererat med ChatGPT
 
@@ -24,6 +25,11 @@ namespace FiaMedKnuff {
         public TileControl() {
             this.InitializeComponent();
         }
+
+        /// <summary>
+        /// Controls whether the click or hover events should run
+        /// </summary>
+        public bool Selectable = true;
 
         /// <summary>
         /// Runs once the component is loaded, after the properties are set in XAML
@@ -94,5 +100,18 @@ namespace FiaMedKnuff {
             set => SetValue(SpaceTypeProperty, value);
         }
 
+        private void Border_Tapped(object sender, TappedRoutedEventArgs e) {
+            if (!Selectable) return;
+            Trace.WriteLine("Boop!");
+        }
+
+        private void Border_PointerEntered(object sender, PointerRoutedEventArgs e) {
+            if (!Selectable) return;
+            Window.Current.CoreWindow.PointerCursor = new CoreCursor(CoreCursorType.Hand, 1);
+        }
+
+        private void Border_PointerExited(object sender, PointerRoutedEventArgs e) {
+            Window.Current.CoreWindow.PointerCursor = new CoreCursor(CoreCursorType.Arrow, 1);
+        }
     }
 }

--- a/FiaMedKnuff/TileControl.xaml.cs
+++ b/FiaMedKnuff/TileControl.xaml.cs
@@ -31,6 +31,8 @@ namespace FiaMedKnuff {
         /// </summary>
         public bool Selectable = true;
 
+        private Tile tile;
+
         /// <summary>
         /// Runs once the component is loaded, after the properties are set in XAML
         /// </summary>
@@ -52,6 +54,7 @@ namespace FiaMedKnuff {
 
             var tile = GameManager.CurrentGame.Tiles[SpaceType][Space];
             tile.TileControl = this;
+            this.tile = tile;
 
             //tile.Update(tile.State);
             tile.Refresh();
@@ -102,7 +105,7 @@ namespace FiaMedKnuff {
 
         private void Border_Tapped(object sender, TappedRoutedEventArgs e) {
             if (!Selectable) return;
-            Trace.WriteLine("Boop!");
+            GameEvents.OnTileClicked(tile);
         }
 
         private void Border_PointerEntered(object sender, PointerRoutedEventArgs e) {

--- a/FiaMedKnuff/TileControl.xaml.cs
+++ b/FiaMedKnuff/TileControl.xaml.cs
@@ -47,7 +47,8 @@ namespace FiaMedKnuff {
             var tile = GameManager.CurrentGame.Tiles[SpaceType][Space];
             tile.TileControl = this;
 
-            tile.Update(tile.State);
+            //tile.Update(tile.State);
+            tile.Refresh();
             //Trace.WriteLine(tile.State);
 
         }


### PR DESCRIPTION
Adds features needed for making the pawns move, as well as some preparations for the future.

- Tiles are now clickable
- Created the class GameEvents to be a more central place for UWP events related to the game.
- Renamed TileState to TeamColor and moved it out of Tile
- Made Tiles store pawns instead of states
- Renamed Tile.Update() to Tile.Refresh()
- Added placeholder Pawn.Move() code for basic movement
- Added documentation to several variables and functions

Bugs:
- Tiles resize for some reason when the image inside is set to visible.
