### PR TITLE
Team winning

### DIFF
--- a/FiaMedKnuff/App.xaml.cs
+++ b/FiaMedKnuff/App.xaml.cs
@@ -30,7 +30,7 @@ namespace FiaMedKnuff
         /// </summary>
         public App()
         {
-            GameManager.Init();
+            //GameManager.Init();
             this.InitializeComponent();
             this.Suspending += OnSuspending;
         }

--- a/FiaMedKnuff/FiaGame/Pawn.cs
+++ b/FiaMedKnuff/FiaGame/Pawn.cs
@@ -64,6 +64,7 @@ namespace FiaMedKnuff.FiaGame {
         /// </summary>
         /// <param name="spaces">Spaces to move forwards</param>
         public void MoveInPath(int spaces) {
+            Win();
             if(CurrentTile.SpaceType == SpaceType.Home)
             {
                 if (GameManager.CurrentDieNumber == 1)
@@ -146,6 +147,8 @@ namespace FiaMedKnuff.FiaGame {
             var tile = CurrentTile;
             CurrentTile.Stander = null;
             CurrentTile.Refresh();
+
+            GamePage.UpdatePawnSlots(Team);
 
             Team.WinCheck();
         }

--- a/FiaMedKnuff/FiaGame/Pawn.cs
+++ b/FiaMedKnuff/FiaGame/Pawn.cs
@@ -26,6 +26,8 @@ namespace FiaMedKnuff.FiaGame {
         public Tile CurrentTile;
         public int SpaceInPath = 0;
 
+        public bool HasWon = false;
+
         public Pawn() { }
 
         public Pawn(Team team, Tile currentTile) {
@@ -92,8 +94,7 @@ namespace FiaMedKnuff.FiaGame {
 
                     if(CurrentTile.SpaceType == SpaceType.Center)
                     {
-                        Frame navigationFrame = Window.Current.Content as Frame;
-                        navigationFrame.Navigate(typeof(ResultatPage));
+                        Win();
                     }
                     if (GameManager.CurrentDieNumber == 6) {
                         string text = "Du får rulla en gång till!";
@@ -135,6 +136,18 @@ namespace FiaMedKnuff.FiaGame {
                     break;
                 }
             }
+        }
+
+        /// <summary>
+        /// Take the pawn out of the game and run Team.WinCheck()
+        /// </summary>
+        public void Win() {
+            HasWon = true;
+            var tile = CurrentTile;
+            CurrentTile.Stander = null;
+            CurrentTile.Refresh();
+
+            Team.WinCheck();
         }
      }
 }

--- a/FiaMedKnuff/FiaGame/Pawn.cs
+++ b/FiaMedKnuff/FiaGame/Pawn.cs
@@ -64,7 +64,6 @@ namespace FiaMedKnuff.FiaGame {
         /// </summary>
         /// <param name="spaces">Spaces to move forwards</param>
         public void MoveInPath(int spaces) {
-            Win();
             if(CurrentTile.SpaceType == SpaceType.Home)
             {
                 if (GameManager.CurrentDieNumber == 1)

--- a/FiaMedKnuff/FiaGame/Team.cs
+++ b/FiaMedKnuff/FiaGame/Team.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml;
 
 namespace FiaMedKnuff.FiaGame {
     public class Team {
@@ -56,6 +58,18 @@ namespace FiaMedKnuff.FiaGame {
                 Path.Add(GameManager.CurrentGame.Tiles[SpaceType.TowardsCenter][TowardsCenterStartingSpace + i]);
             }
             Path.Add(GameManager.CurrentGame.Tiles[SpaceType.Center][0]);
+        }
+
+        /// <summary>
+        /// If all pawns have won, go to the end screen
+        /// </summary>
+        public void WinCheck() {
+            if (!Pawns.All(pawn => pawn.HasWon)) return;
+
+            ResultatPage.WinningTeam = TeamColor;
+            Frame navigationFrame = Window.Current.Content as Frame;
+            navigationFrame.Navigate(typeof(ResultatPage));
+
         }
     }
 }

--- a/FiaMedKnuff/GamePage.xaml
+++ b/FiaMedKnuff/GamePage.xaml
@@ -84,50 +84,254 @@
 
     <Grid x:Name="ParentGrid" SizeChanged="ParentGrid_SizeChanged">
         <Grid>
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="280"></ColumnDefinition>
-                <ColumnDefinition MinWidth="1000"></ColumnDefinition>
-                <ColumnDefinition Width="280"></ColumnDefinition>
-            </Grid.ColumnDefinitions>
-            <StackPanel Grid.Column="0">
-                <Button Width="270" Height="75" Content="Nytt Spel" Background="{StaticResource OrangeButton}" BorderBrush="Black" BorderThickness="5" CornerRadius="15" FontSize="40" FontFamily="Inconsolata" HorizontalAlignment="Left" Margin="10,10,0,0" Click="NyttSpelBtn_Click" Style="{StaticResource ButtonStyleFixOrangeGlobal}" Foreground="{StaticResource StandardText}"/>
-            </StackPanel>
-            <StackPanel Grid.Column="2">
-                <Button Opacity="0.5" Name="SettingsBtn" Width="75" Height="75" Background="White" BorderBrush="Black" BorderThickness="5" CornerRadius="15" HorizontalAlignment="Right" VerticalAlignment="Top" Margin="0,10,10,0" Click="SettingsBtn_Click" Style="{StaticResource ButtonStyleFixWhiteGlobal}">
-                    <Image Width="45" Height="45" HorizontalAlignment="Center" VerticalAlignment="Center" Source="/Assets/cogwheel_83806.png" />
-                </Button>
-                <Button Name="RulesBtn" Content="?" Width="75" Height="75" Background="{StaticResource WhiteButton}" FontSize="50" FontFamily="Inconsolata" FontWeight="Bold" BorderBrush="Black" BorderThickness="5" CornerRadius="15" HorizontalAlignment="Right" Margin="0,10,10,0" Click="RulesBtn_Click" Style="{StaticResource ButtonStyleFixWhiteGlobal}" Foreground="{StaticResource StandardText}"/>
-            </StackPanel>
-            <Grid Grid.Column="1">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*"/>
-                    <ColumnDefinition Width="Auto"/>
-                    <ColumnDefinition Width="*"/>
-                </Grid.ColumnDefinitions>
+            <Grid HorizontalAlignment="Center" Width="Auto" Margin="10">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="*"/>
                     <RowDefinition Height="Auto"/>
                 </Grid.RowDefinitions>
-                <!-- Gråa bitar -->
-                <StackPanel Grid.Column="0" Grid.Row="0" HorizontalAlignment="Right">
-                    <!-- TODO: Put pawns here -->
+                <!-- Game Board and Pawn Slots -->
+                <StackPanel Grid.Row="0" Orientation="Horizontal">
+                    <!-- Left Pawn Slots -->
+                    <Grid Width="36">
+                        <StackPanel VerticalAlignment="Top" Orientation="Vertical" x:Name="BlueSlots">
+                            <Image Source="Assets/Pawns/PawnSlot.png"></Image>
+                            <Image Source="Assets/Pawns/PawnSlot.png"></Image>
+                            <Image Source="Assets/Pawns/PawnSlot.png"></Image>
+                            <Image Source="Assets/Pawns/PawnSlot.png"></Image>
+                        </StackPanel>
+
+                        <StackPanel VerticalAlignment="Bottom" Orientation="Vertical" x:Name="GreenSlots">
+                            <Image Source="Assets/Pawns/PawnSlot.png"></Image>
+                            <Image Source="Assets/Pawns/PawnSlot.png"></Image>
+                            <Image Source="Assets/Pawns/PawnSlot.png"></Image>
+                            <Image Source="Assets/Pawns/PawnSlot.png"></Image>
+                        </StackPanel>
+                    </Grid>
+                    <!-- Game board -->
+                    <Grid Width="Auto">
+                        <Border Style="{StaticResource CommonBorder}">
+                            <Viewbox Stretch="Uniform">
+                                <!-- Board content -->
+                                <Grid Background="White" Padding="30">
+                                    <!-- Spaces -->
+                                    <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="76"/>
+                                            <ColumnDefinition Width="76"/>
+                                            <ColumnDefinition Width="76"/>
+                                            <ColumnDefinition Width="76"/>
+                                            <ColumnDefinition Width="76"/>
+                                            <ColumnDefinition Width="76"/>
+                                            <ColumnDefinition Width="76"/>
+                                            <ColumnDefinition Width="76"/>
+                                            <ColumnDefinition Width="76"/>
+                                            <ColumnDefinition Width="76"/>
+                                            <ColumnDefinition Width="76"/>
+                                        </Grid.ColumnDefinitions>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="76"/>
+                                            <RowDefinition Height="76"/>
+                                            <RowDefinition Height="76"/>
+                                            <RowDefinition Height="76"/>
+                                            <RowDefinition Height="76"/>
+                                            <RowDefinition Height="76"/>
+                                            <RowDefinition Height="76"/>
+                                            <RowDefinition Height="76"/>
+                                            <RowDefinition Height="76"/>
+                                            <RowDefinition Height="76"/>
+                                            <RowDefinition Height="76"/>
+                                        </Grid.RowDefinitions>
+
+                                        <!-- Center tile -->
+                                        <local:TileControl Space="0" SpaceType="Center" Grid.Column="5" Grid.Row="5"/>
+
+                                        <!-- Surrounding tiles -->
+                                        <local:TileControl Space="0" Grid.Column="4" Grid.Row="0"/>
+                                        <local:TileControl Space="1" Grid.Column="5" Grid.Row="0"/>
+                                        <local:TileControl Space="2" Grid.Column="6" Grid.Row="0" BackgroundColor="{StaticResource RedTeam}"/>
+                                        <local:TileControl Space="3" Grid.Column="6" Grid.Row="1"/>
+                                        <local:TileControl Space="4" Grid.Column="6" Grid.Row="2"/>
+                                        <local:TileControl Space="5" Grid.Column="6" Grid.Row="3"/>
+                                        <local:TileControl Space="6" Grid.Column="6" Grid.Row="4"/>
+                                        <local:TileControl Space="7" Grid.Column="7" Grid.Row="4"/>
+                                        <local:TileControl Space="8" Grid.Column="8" Grid.Row="4"/>
+                                        <local:TileControl Space="9" Grid.Column="9" Grid.Row="4"/>
+                                        <local:TileControl Space="10" Grid.Column="10" Grid.Row="4"/>
+                                        <local:TileControl Space="11" Grid.Column="10" Grid.Row="5"/>
+                                        <local:TileControl Space="12" Grid.Column="10" Grid.Row="6" BackgroundColor="{StaticResource YellowTeam}"/>
+                                        <local:TileControl Space="13" Grid.Column="9" Grid.Row="6"/>
+                                        <local:TileControl Space="14" Grid.Column="8" Grid.Row="6"/>
+                                        <local:TileControl Space="15" Grid.Column="7" Grid.Row="6"/>
+                                        <local:TileControl Space="16" Grid.Column="6" Grid.Row="6"/>
+                                        <local:TileControl Space="17" Grid.Column="6" Grid.Row="7"/>
+                                        <local:TileControl Space="18" Grid.Column="6" Grid.Row="8"/>
+                                        <local:TileControl Space="19" Grid.Column="6" Grid.Row="9"/>
+                                        <local:TileControl Space="20" Grid.Column="6" Grid.Row="10"/>
+                                        <local:TileControl Space="21" Grid.Column="5" Grid.Row="10"/>
+                                        <local:TileControl Space="22" Grid.Column="4" Grid.Row="10" BackgroundColor="{StaticResource GreenTeam}"/>
+                                        <local:TileControl Space="23" Grid.Column="4" Grid.Row="9"/>
+                                        <local:TileControl Space="24" Grid.Column="4" Grid.Row="8"/>
+                                        <local:TileControl Space="25" Grid.Column="4" Grid.Row="7"/>
+                                        <local:TileControl Space="26" Grid.Column="4" Grid.Row="6"/>
+                                        <local:TileControl Space="27" Grid.Column="3" Grid.Row="6"/>
+                                        <local:TileControl Space="28" Grid.Column="2" Grid.Row="6"/>
+                                        <local:TileControl Space="29" Grid.Column="1" Grid.Row="6"/>
+                                        <local:TileControl Space="30" Grid.Column="0" Grid.Row="6"/>
+                                        <local:TileControl Space="31" Grid.Column="0" Grid.Row="5"/>
+                                        <local:TileControl Space="32" Grid.Column="0" Grid.Row="4" BackgroundColor="{StaticResource BlueTeam}"/>
+                                        <local:TileControl Space="33" Grid.Column="1" Grid.Row="4"/>
+                                        <local:TileControl Space="34" Grid.Column="2" Grid.Row="4"/>
+                                        <local:TileControl Space="35" Grid.Column="3" Grid.Row="4"/>
+                                        <local:TileControl Space="36" Grid.Column="4" Grid.Row="4"/>
+                                        <local:TileControl Space="37" Grid.Column="4" Grid.Row="3"/>
+                                        <local:TileControl Space="38" Grid.Column="4" Grid.Row="2"/>
+                                        <local:TileControl Space="39" Grid.Column="4" Grid.Row="1"/>
+
+                                        <!-- Color tiles -->
+                                        <!-- Red team -->
+                                        <local:TileControl Space="0" SpaceType="TowardsCenter" Grid.Column="5" Grid.Row="1" BackgroundColor="{StaticResource RedTeam}"/>
+                                        <local:TileControl Space="1" SpaceType="TowardsCenter" Grid.Column="5" Grid.Row="2" BackgroundColor="{StaticResource RedTeam}"/>
+                                        <local:TileControl Space="2" SpaceType="TowardsCenter" Grid.Column="5" Grid.Row="3" BackgroundColor="{StaticResource RedTeam}"/>
+                                        <local:TileControl Space="3" SpaceType="TowardsCenter" Grid.Column="5" Grid.Row="4" BackgroundColor="{StaticResource RedTeam}"/>
+                                        <!-- Yellow team -->
+                                        <local:TileControl Space="4" SpaceType="TowardsCenter" Grid.Column="9" Grid.Row="5" BackgroundColor="{StaticResource YellowTeam}"/>
+                                        <local:TileControl Space="5" SpaceType="TowardsCenter" Grid.Column="8" Grid.Row="5" BackgroundColor="{StaticResource YellowTeam}"/>
+                                        <local:TileControl Space="6" SpaceType="TowardsCenter" Grid.Column="7" Grid.Row="5" BackgroundColor="{StaticResource YellowTeam}"/>
+                                        <local:TileControl Space="7" SpaceType="TowardsCenter" Grid.Column="6" Grid.Row="5" BackgroundColor="{StaticResource YellowTeam}"/>
+                                        <!-- Green team -->
+                                        <local:TileControl Space="8" SpaceType="TowardsCenter" Grid.Column="5" Grid.Row="9" BackgroundColor="{StaticResource GreenTeam}"/>
+                                        <local:TileControl Space="9" SpaceType="TowardsCenter" Grid.Column="5" Grid.Row="8" BackgroundColor="{StaticResource GreenTeam}"/>
+                                        <local:TileControl Space="10" SpaceType="TowardsCenter" Grid.Column="5" Grid.Row="7" BackgroundColor="{StaticResource GreenTeam}"/>
+                                        <local:TileControl Space="11" SpaceType="TowardsCenter" Grid.Column="5" Grid.Row="6" BackgroundColor="{StaticResource GreenTeam}"/>
+                                        <!-- Blue team -->
+                                        <local:TileControl ImageSource="/Assets/Pawn.png"  Space="12" SpaceType="TowardsCenter" Grid.Column="1" Grid.Row="5" BackgroundColor="{StaticResource BlueTeam}"/>
+                                        <local:TileControl Space="13" SpaceType="TowardsCenter" Grid.Column="2" Grid.Row="5" BackgroundColor="{StaticResource BlueTeam}"/>
+                                        <local:TileControl Space="14" SpaceType="TowardsCenter" Grid.Column="3" Grid.Row="5" BackgroundColor="{StaticResource BlueTeam}"/>
+                                        <local:TileControl Space="15" SpaceType="TowardsCenter" Grid.Column="4" Grid.Row="5" BackgroundColor="{StaticResource BlueTeam}"/>
+
+                                        <!-- Team circles -->
+                                        <!-- Red -->
+                                        <Border x:Name="RedBorder" Grid.Column="8" Grid.ColumnSpan="3" Grid.RowSpan="3" BorderBrush="{StaticResource StandardWhite}" BorderThickness="5" CornerRadius="150">
+                                            <Border BorderThickness="5" BorderBrush="{StaticResource Border}" Margin="5" Background="{StaticResource RedTeam}" CornerRadius="150">
+                                                <Grid Padding="20">
+                                                    <Grid.RowDefinitions>
+                                                        <RowDefinition Height="*" />
+                                                        <RowDefinition Height="*" />
+                                                    </Grid.RowDefinitions>
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="*" />
+                                                        <ColumnDefinition Width="*" />
+                                                    </Grid.ColumnDefinitions>
+
+                                                    <local:TileControl ImageVisibility="Visible" Space="0" SpaceType="Home" Grid.Column="0" Grid.Row="0"/>
+                                                    <local:TileControl ImageVisibility="Visible" Space="1" SpaceType="Home" Grid.Column="1" Grid.Row="0"/>
+                                                    <!-- Raden ovanför ska ha detta oxo: Loaded="TileControl_Loaded"-->
+                                                    <local:TileControl ImageVisibility="Visible" Space="2" SpaceType="Home" Grid.Column="0" Grid.Row="1"/>
+                                                    <local:TileControl ImageVisibility="Visible" Space="3" SpaceType="Home" Grid.Column="1" Grid.Row="1"/>
+
+                                                </Grid>
+                                            </Border>
+                                        </Border>
+
+                                        <!-- Yellow -->
+                                        <Border x:Name="YellowBorder" Grid.Column="8" Grid.Row="8" Grid.ColumnSpan="3" Grid.RowSpan="3" BorderBrush="{StaticResource StandardWhite}" BorderThickness="5" CornerRadius="150">
+                                            <Border BorderThickness="5" BorderBrush="{StaticResource Border}" Margin="5" Background="{StaticResource YellowTeam}" CornerRadius="150">
+                                                <Grid Padding="20">
+                                                    <Grid.RowDefinitions>
+                                                        <RowDefinition Height="*" />
+                                                        <RowDefinition Height="*" />
+                                                    </Grid.RowDefinitions>
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="*" />
+                                                        <ColumnDefinition Width="*" />
+                                                    </Grid.ColumnDefinitions>
+
+                                                    <local:TileControl Space="4" SpaceType="Home" Grid.Column="0" Grid.Row="0"/>
+                                                    <local:TileControl Space="5" SpaceType="Home" Grid.Column="1" Grid.Row="0"/>
+                                                    <local:TileControl Space="6" SpaceType="Home" Grid.Column="0" Grid.Row="1"/>
+                                                    <local:TileControl Space="7" SpaceType="Home" Grid.Column="1" Grid.Row="1"/>
+
+                                                </Grid>
+                                            </Border>
+                                        </Border>
+
+                                        <!-- Green -->
+                                        <Border x:Name="GreenBorder" Grid.Row="8" Grid.ColumnSpan="3" Grid.RowSpan="3" BorderBrush="{StaticResource StandardWhite}" BorderThickness="5" CornerRadius="150">
+                                            <Border BorderThickness="5" BorderBrush="{StaticResource Border}" Margin="5" Background="{StaticResource GreenTeam}" CornerRadius="150">
+                                                <Grid Padding="20">
+                                                    <Grid.RowDefinitions>
+                                                        <RowDefinition Height="*" />
+                                                        <RowDefinition Height="*" />
+                                                    </Grid.RowDefinitions>
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="*" />
+                                                        <ColumnDefinition Width="*" />
+                                                    </Grid.ColumnDefinitions>
+
+                                                    <local:TileControl Space="8" SpaceType="Home" Grid.Column="0" Grid.Row="0"/>
+                                                    <local:TileControl Space="9" SpaceType="Home" Grid.Column="1" Grid.Row="0"/>
+                                                    <local:TileControl Space="10" SpaceType="Home" Grid.Column="0" Grid.Row="1"/>
+                                                    <local:TileControl Space="11" SpaceType="Home" Grid.Column="1" Grid.Row="1"/>
+
+                                                </Grid>
+                                            </Border>
+                                        </Border>
+
+                                        <!-- Blue -->
+                                        <Border x:Name="BlueBorder" Grid.ColumnSpan="3" Grid.RowSpan="3" BorderBrush="{StaticResource StandardWhite}" BorderThickness="5" CornerRadius="150">
+                                            <Border BorderThickness="5" BorderBrush="{StaticResource Border}" Margin="5" Background="{StaticResource BlueTeam}" CornerRadius="150">
+                                                <Grid Padding="20">
+                                                    <Grid.RowDefinitions>
+                                                        <RowDefinition Height="*" />
+                                                        <RowDefinition Height="*" />
+                                                    </Grid.RowDefinitions>
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="*" />
+                                                        <ColumnDefinition Width="*" />
+                                                    </Grid.ColumnDefinitions>
+
+                                                    <local:TileControl Space="12" SpaceType="Home" Grid.Column="0" Grid.Row="0"/>
+                                                    <local:TileControl Space="13" SpaceType="Home" Grid.Column="1" Grid.Row="0"/>
+                                                    <local:TileControl Space="14" SpaceType="Home" Grid.Column="0" Grid.Row="1"/>
+                                                    <local:TileControl Space="15" SpaceType="Home" Grid.Column="1" Grid.Row="1"/>
+
+                                                </Grid>
+                                            </Border>
+                                        </Border>
+                                    </Grid>
+                                </Grid>
+                            </Viewbox>
+                        </Border>
+                    </Grid>
+                    <!-- Right Pawn Slots -->
+                    <Grid Width="36">
+                        <StackPanel VerticalAlignment="Top" Orientation="Vertical" x:Name="RedSlots">
+                            <Image Source="Assets/Pawns/PawnSlot.png"></Image>
+                            <Image Source="Assets/Pawns/PawnSlot.png"></Image>
+                            <Image Source="Assets/Pawns/PawnSlot.png"></Image>
+                            <Image Source="Assets/Pawns/PawnSlot.png"></Image>
+                        </StackPanel>
+
+                        <StackPanel VerticalAlignment="Bottom" Orientation="Vertical" x:Name="YellowSlots">
+                            <Image Source="Assets/Pawns/PawnSlot.png"></Image>
+                            <Image Source="Assets/Pawns/PawnSlot.png"></Image>
+                            <Image Source="Assets/Pawns/PawnSlot.png"></Image>
+                            <Image Source="Assets/Pawns/PawnSlot.png"></Image>
+                        </StackPanel>
+                    </Grid>
                 </StackPanel>
-                <StackPanel Grid.Column="2" Grid.Row="0" HorizontalAlignment="Left">
-                    <!-- TODO: Put pawns here -->
-                </StackPanel>
-                <!-- InfoBox -->
-                <Grid Grid.Column="1" Grid.Row="1" Height="100">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="500"/>
-                        <ColumnDefinition Width="Auto"/>
-                    </Grid.ColumnDefinitions>
-                    <Grid BorderThickness="5" BorderBrush="Black" Grid.Column="0" CornerRadius="5" Background="White" Margin="10">
+                <!-- ...End of game board -->
+
+                <!-- InfoBox and Die-->
+                <StackPanel Grid.Row="1" Orientation="Horizontal" Height="100" Padding="0, 10">
+                    <!-- Info Box -->
+                    <Grid BorderThickness="5" BorderBrush="Black" CornerRadius="5" Background="White" Width="450" Padding="10, 0">
                         <Grid VerticalAlignment="Center" HorizontalAlignment="Center">
                             <TextBlock x:Name="DieTextBlock" Foreground="{StaticResource StandardText}" TextWrapping="Wrap" Text="Tryck på tärningen" FontSize="30" FontFamily="Inconsolata"/>
                         </Grid>
                     </Grid>
                     <!-- Die -->
-                    <Grid Grid.Column="1" Width="70" Height="70" Background="Transparent">
+                    <Grid Width="70" Height="70" Background="Transparent" Margin="10, 0, 0, 0">
                         <Border x:Name="dieBtnBorder" BorderThickness="4" BorderBrush="Yellow" Background="White" Width="60" Height="60" CornerRadius="10" HorizontalAlignment="Center"/>
                         <Button Style="{StaticResource ButtonStyleDie}" x:Name="DieButton" HorizontalAlignment="Center" Content="" Width="50" Height="50" Click="DieButton_Click">
                             <Button.Background>
@@ -135,224 +339,24 @@
                             </Button.Background>
                         </Button>
                     </Grid>
-                </Grid>
-                <!-- Game board -->
-                <Grid Grid.Column="1" Grid.Row="0" HorizontalAlignment="Center" VerticalAlignment="Center">
-                    <Border Style="{StaticResource CommonBorder}">
-                        <Grid>
-                            <Viewbox Stretch="Uniform">
-                                <Grid Background="White" MinWidth="100" MinHeight="100" HorizontalAlignment="Center">
-                                </Grid>
-                            </Viewbox>
-                            <!-- Board content -->
-                            <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Padding="30">
-                                <!-- Spaces -->
-                                <Grid HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="76"/>
-                                        <ColumnDefinition Width="76"/>
-                                        <ColumnDefinition Width="76"/>
-                                        <ColumnDefinition Width="76"/>
-                                        <ColumnDefinition Width="76"/>
-                                        <ColumnDefinition Width="76"/>
-                                        <ColumnDefinition Width="76"/>
-                                        <ColumnDefinition Width="76"/>
-                                        <ColumnDefinition Width="76"/>
-                                        <ColumnDefinition Width="76"/>
-                                        <ColumnDefinition Width="76"/>
-                                    </Grid.ColumnDefinitions>
-                                    <Grid.RowDefinitions>
-                                        <RowDefinition Height="76"/>
-                                        <RowDefinition Height="76"/>
-                                        <RowDefinition Height="76"/>
-                                        <RowDefinition Height="76"/>
-                                        <RowDefinition Height="76"/>
-                                        <RowDefinition Height="76"/>
-                                        <RowDefinition Height="76"/>
-                                        <RowDefinition Height="76"/>
-                                        <RowDefinition Height="76"/>
-                                        <RowDefinition Height="76"/>
-                                        <RowDefinition Height="76"/>
-                                    </Grid.RowDefinitions>
-
-                                    <!-- Center tile -->
-                                    <local:TileControl Space="0" SpaceType="Center" Grid.Column="5" Grid.Row="5"/>
-
-                                    <!-- Surrounding tiles -->
-                                    <local:TileControl Space="0" Grid.Column="4" Grid.Row="0"/>
-                                    <local:TileControl Space="1" Grid.Column="5" Grid.Row="0"/>
-                                    <local:TileControl Space="2" Grid.Column="6" Grid.Row="0" BackgroundColor="{StaticResource RedTeam}"/>
-                                    <local:TileControl Space="3" Grid.Column="6" Grid.Row="1"/>
-                                    <local:TileControl Space="4" Grid.Column="6" Grid.Row="2"/>
-                                    <local:TileControl Space="5" Grid.Column="6" Grid.Row="3"/>
-                                    <local:TileControl Space="6" Grid.Column="6" Grid.Row="4"/>
-                                    <local:TileControl Space="7" Grid.Column="7" Grid.Row="4"/>
-                                    <local:TileControl Space="8" Grid.Column="8" Grid.Row="4"/>
-                                    <local:TileControl Space="9" Grid.Column="9" Grid.Row="4"/>
-                                    <local:TileControl Space="10" Grid.Column="10" Grid.Row="4"/>
-                                    <local:TileControl Space="11" Grid.Column="10" Grid.Row="5"/>
-                                    <local:TileControl Space="12" Grid.Column="10" Grid.Row="6" BackgroundColor="{StaticResource YellowTeam}"/>
-                                    <local:TileControl Space="13" Grid.Column="9" Grid.Row="6"/>
-                                    <local:TileControl Space="14" Grid.Column="8" Grid.Row="6"/>
-                                    <local:TileControl Space="15" Grid.Column="7" Grid.Row="6"/>
-                                    <local:TileControl Space="16" Grid.Column="6" Grid.Row="6"/>
-                                    <local:TileControl Space="17" Grid.Column="6" Grid.Row="7"/>
-                                    <local:TileControl Space="18" Grid.Column="6" Grid.Row="8"/>
-                                    <local:TileControl Space="19" Grid.Column="6" Grid.Row="9"/>
-                                    <local:TileControl Space="20" Grid.Column="6" Grid.Row="10"/>
-                                    <local:TileControl Space="21" Grid.Column="5" Grid.Row="10"/>
-                                    <local:TileControl Space="22" Grid.Column="4" Grid.Row="10" BackgroundColor="{StaticResource GreenTeam}"/>
-                                    <local:TileControl Space="23" Grid.Column="4" Grid.Row="9"/>
-                                    <local:TileControl Space="24" Grid.Column="4" Grid.Row="8"/>
-                                    <local:TileControl Space="25" Grid.Column="4" Grid.Row="7"/>
-                                    <local:TileControl Space="26" Grid.Column="4" Grid.Row="6"/>
-                                    <local:TileControl Space="27" Grid.Column="3" Grid.Row="6"/>
-                                    <local:TileControl Space="28" Grid.Column="2" Grid.Row="6"/>
-                                    <local:TileControl Space="29" Grid.Column="1" Grid.Row="6"/>
-                                    <local:TileControl Space="30" Grid.Column="0" Grid.Row="6"/>
-                                    <local:TileControl Space="31" Grid.Column="0" Grid.Row="5"/>
-                                    <local:TileControl Space="32" Grid.Column="0" Grid.Row="4" BackgroundColor="{StaticResource BlueTeam}"/>
-                                    <local:TileControl Space="33" Grid.Column="1" Grid.Row="4"/>
-                                    <local:TileControl Space="34" Grid.Column="2" Grid.Row="4"/>
-                                    <local:TileControl Space="35" Grid.Column="3" Grid.Row="4"/>
-                                    <local:TileControl Space="36" Grid.Column="4" Grid.Row="4"/>
-                                    <local:TileControl Space="37" Grid.Column="4" Grid.Row="3"/>
-                                    <local:TileControl Space="38" Grid.Column="4" Grid.Row="2"/>
-                                    <local:TileControl Space="39" Grid.Column="4" Grid.Row="1"/>
-
-                                    <!-- Color tiles -->
-                                    <!-- Red team -->
-                                    <local:TileControl Space="0" SpaceType="TowardsCenter" Grid.Column="5" Grid.Row="1" BackgroundColor="{StaticResource RedTeam}"/>
-                                    <local:TileControl Space="1" SpaceType="TowardsCenter" Grid.Column="5" Grid.Row="2" BackgroundColor="{StaticResource RedTeam}"/>
-                                    <local:TileControl Space="2" SpaceType="TowardsCenter" Grid.Column="5" Grid.Row="3" BackgroundColor="{StaticResource RedTeam}"/>
-                                    <local:TileControl Space="3" SpaceType="TowardsCenter" Grid.Column="5" Grid.Row="4" BackgroundColor="{StaticResource RedTeam}"/>
-                                    <!-- Yellow team -->
-                                    <local:TileControl Space="4" SpaceType="TowardsCenter" Grid.Column="9" Grid.Row="5" BackgroundColor="{StaticResource YellowTeam}"/>
-                                    <local:TileControl Space="5" SpaceType="TowardsCenter" Grid.Column="8" Grid.Row="5" BackgroundColor="{StaticResource YellowTeam}"/>
-                                    <local:TileControl Space="6" SpaceType="TowardsCenter" Grid.Column="7" Grid.Row="5" BackgroundColor="{StaticResource YellowTeam}"/>
-                                    <local:TileControl Space="7" SpaceType="TowardsCenter" Grid.Column="6" Grid.Row="5" BackgroundColor="{StaticResource YellowTeam}"/>
-                                    <!-- Green team -->
-                                    <local:TileControl Space="8" SpaceType="TowardsCenter" Grid.Column="5" Grid.Row="9" BackgroundColor="{StaticResource GreenTeam}"/>
-                                    <local:TileControl Space="9" SpaceType="TowardsCenter" Grid.Column="5" Grid.Row="8" BackgroundColor="{StaticResource GreenTeam}"/>
-                                    <local:TileControl Space="10" SpaceType="TowardsCenter" Grid.Column="5" Grid.Row="7" BackgroundColor="{StaticResource GreenTeam}"/>
-                                    <local:TileControl Space="11" SpaceType="TowardsCenter" Grid.Column="5" Grid.Row="6" BackgroundColor="{StaticResource GreenTeam}"/>
-                                    <!-- Blue team -->
-                                    <local:TileControl ImageSource="/Assets/Pawn.png"  Space="12" SpaceType="TowardsCenter" Grid.Column="1" Grid.Row="5" BackgroundColor="{StaticResource BlueTeam}"/>
-                                    <local:TileControl Space="13" SpaceType="TowardsCenter" Grid.Column="2" Grid.Row="5" BackgroundColor="{StaticResource BlueTeam}"/>
-                                    <local:TileControl Space="14" SpaceType="TowardsCenter" Grid.Column="3" Grid.Row="5" BackgroundColor="{StaticResource BlueTeam}"/>
-                                    <local:TileControl Space="15" SpaceType="TowardsCenter" Grid.Column="4" Grid.Row="5" BackgroundColor="{StaticResource BlueTeam}"/>
-
-                                    <!-- Team circles -->
-                                    <!-- Red -->
-                                    <Border x:Name="RedBorder" Grid.Column="8" Grid.ColumnSpan="3" Grid.RowSpan="3" BorderBrush="{StaticResource StandardWhite}" BorderThickness="5" CornerRadius="150">
-                                        <Border BorderThickness="5" BorderBrush="{StaticResource Border}" Margin="5" Background="{StaticResource RedTeam}" CornerRadius="150">
-                                            <Grid Padding="20">
-                                                <Grid.RowDefinitions>
-                                                    <RowDefinition Height="*" />
-                                                    <RowDefinition Height="*" />
-                                                </Grid.RowDefinitions>
-                                                <Grid.ColumnDefinitions>
-                                                    <ColumnDefinition Width="*" />
-                                                    <ColumnDefinition Width="*" />
-                                                </Grid.ColumnDefinitions>
-
-                                                <local:TileControl ImageVisibility="Visible" Space="0" SpaceType="Home" Grid.Column="0" Grid.Row="0"/>
-                                                <local:TileControl ImageVisibility="Visible" Space="1" SpaceType="Home" Grid.Column="1" Grid.Row="0"/>
-                                                <!-- Raden ovanför ska ha detta oxo: Loaded="TileControl_Loaded"-->
-                                                <local:TileControl ImageVisibility="Visible" Space="2" SpaceType="Home" Grid.Column="0" Grid.Row="1"/>
-                                                <local:TileControl ImageVisibility="Visible" Space="3" SpaceType="Home" Grid.Column="1" Grid.Row="1"/>
-
-                                            </Grid>
-                                        </Border>
-                                    </Border>
-
-                                    <!-- Yellow -->
-                                    <Border x:Name="YellowBorder" Grid.Column="8" Grid.Row="8" Grid.ColumnSpan="3" Grid.RowSpan="3" BorderBrush="{StaticResource StandardWhite}" BorderThickness="5" CornerRadius="150">
-                                        <Border BorderThickness="5" BorderBrush="{StaticResource Border}" Margin="5" Background="{StaticResource YellowTeam}" CornerRadius="150">
-                                            <Grid Padding="20">
-                                                <Grid.RowDefinitions>
-                                                    <RowDefinition Height="*" />
-                                                    <RowDefinition Height="*" />
-                                                </Grid.RowDefinitions>
-                                                <Grid.ColumnDefinitions>
-                                                    <ColumnDefinition Width="*" />
-                                                    <ColumnDefinition Width="*" />
-                                                </Grid.ColumnDefinitions>
-
-                                                <local:TileControl Space="4" SpaceType="Home" Grid.Column="0" Grid.Row="0"/>
-                                                <local:TileControl Space="5" SpaceType="Home" Grid.Column="1" Grid.Row="0"/>
-                                                <local:TileControl Space="6" SpaceType="Home" Grid.Column="0" Grid.Row="1"/>
-                                                <local:TileControl Space="7" SpaceType="Home" Grid.Column="1" Grid.Row="1"/>
-
-                                            </Grid>
-                                        </Border>
-                                    </Border>
-
-                                    <!-- Green -->
-                                    <Border x:Name="GreenBorder" Grid.Row="8" Grid.ColumnSpan="3" Grid.RowSpan="3" BorderBrush="{StaticResource StandardWhite}" BorderThickness="5" CornerRadius="150">
-                                        <Border BorderThickness="5" BorderBrush="{StaticResource Border}" Margin="5" Background="{StaticResource GreenTeam}" CornerRadius="150">
-                                            <Grid Padding="20">
-                                                <Grid.RowDefinitions>
-                                                    <RowDefinition Height="*" />
-                                                    <RowDefinition Height="*" />
-                                                </Grid.RowDefinitions>
-                                                <Grid.ColumnDefinitions>
-                                                    <ColumnDefinition Width="*" />
-                                                    <ColumnDefinition Width="*" />
-                                                </Grid.ColumnDefinitions>
-
-                                                <local:TileControl Space="8" SpaceType="Home" Grid.Column="0" Grid.Row="0"/>
-                                                <local:TileControl Space="9" SpaceType="Home" Grid.Column="1" Grid.Row="0"/>
-                                                <local:TileControl Space="10" SpaceType="Home" Grid.Column="0" Grid.Row="1"/>
-                                                <local:TileControl Space="11" SpaceType="Home" Grid.Column="1" Grid.Row="1"/>
-
-                                            </Grid>
-                                        </Border>
-                                    </Border>
-
-                                    <!-- Blue -->
-                                    <Border x:Name="BlueBorder" Grid.ColumnSpan="3" Grid.RowSpan="3" BorderBrush="{StaticResource StandardWhite}" BorderThickness="5" CornerRadius="150">
-                                        <Border BorderThickness="5" BorderBrush="{StaticResource Border}" Margin="5" Background="{StaticResource BlueTeam}" CornerRadius="150">
-                                            <Grid Padding="20">
-                                                <Grid.RowDefinitions>
-                                                    <RowDefinition Height="*" />
-                                                    <RowDefinition Height="*" />
-                                                </Grid.RowDefinitions>
-                                                <Grid.ColumnDefinitions>
-                                                    <ColumnDefinition Width="*" />
-                                                    <ColumnDefinition Width="*" />
-                                                </Grid.ColumnDefinitions>
-
-                                                <local:TileControl Space="12" SpaceType="Home" Grid.Column="0" Grid.Row="0"/>
-                                                <local:TileControl Space="13" SpaceType="Home" Grid.Column="1" Grid.Row="0"/>
-                                                <local:TileControl Space="14" SpaceType="Home" Grid.Column="0" Grid.Row="1"/>
-                                                <local:TileControl Space="15" SpaceType="Home" Grid.Column="1" Grid.Row="1"/>
-
-                                            </Grid>
-                                        </Border>
-                                    </Border>
-                                </Grid>
-                            </Grid>
-                        </Grid>
-                    </Border>
-                </Grid>
+                </StackPanel>
             </Grid>
 
-
-            <!--<Popup Name="RulesPopup" IsOpen="False" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
-                <Grid Name="RulesPopupGrid" Background="#80000000">
-                    <Grid Background="{StaticResource StandardOrange}" BorderBrush="Black" BorderThickness="5" Width="1030" Height="800" Margin="400,105,645,105">
-                        <ScrollViewer VerticalScrollBarVisibility="Visible" HorizontalScrollBarVisibility="Disabled">
-                            <TextBlock Name="RulesText" Width="950" Text="Placeholder Text" HorizontalAlignment="Center" VerticalAlignment="Top" FontSize="28" FontFamily="Inconsolata" Margin="0,60,0,0"/>
-                        </ScrollViewer>
-                        <Button Name="RulesCloseBtn" Width="70" Height="70" HorizontalAlignment="Right" VerticalAlignment="Top" Content="x" Foreground="Red" Background="{StaticResource WhiteButton}" BorderBrush="Black" BorderThickness="5" CornerRadius="15" FontSize="50" Padding="0,0,2,0" FontFamily="Inconsolata" Margin="0,10,10,0" Click="CloseBtn_Click"/>
-                    </Grid>
-                </Grid>
-            </Popup>-->
+            <StackPanel>
+                <Button Width="200" Height="70" Content="Nytt Spel" Background="{StaticResource OrangeButton}" BorderBrush="Black" BorderThickness="5" CornerRadius="15" FontSize="30" FontFamily="Inconsolata" HorizontalAlignment="Left" Margin="10,10,0,0" Click="NyttSpelBtn_Click" Style="{StaticResource ButtonStyleFixOrangeGlobal}" Foreground="{StaticResource StandardText}"/>
+            </StackPanel>
+            <StackPanel HorizontalAlignment="Right" VerticalAlignment="Top" Margin="10">
+                <Button Opacity="0.5" Name="SettingsBtn" Width="75" Height="75" Background="White" BorderBrush="Black" BorderThickness="5" CornerRadius="15" Margin="0,0,0,10" Click="SettingsBtn_Click" Style="{StaticResource ButtonStyleFixWhiteGlobal}">
+                    <Image Width="45" Height="45" HorizontalAlignment="Center" VerticalAlignment="Center" Source="/Assets/cogwheel_83806.png" />
+                </Button>
+                <Button Name="RulesBtn" Content="?" Width="75" Height="75" Background="{StaticResource WhiteButton}" FontSize="50" FontFamily="Inconsolata" FontWeight="Bold" BorderBrush="Black" BorderThickness="5" CornerRadius="15" Click="RulesBtn_Click" Style="{StaticResource ButtonStyleFixWhiteGlobal}" Foreground="{StaticResource StandardText}"/>
+            </StackPanel>
+            
+            <!-- Popups -->
 
             <Popup Name="DieResultDecisionPopup" IsOpen="False" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
-                <Grid Background="#80000000">
-                    <Grid Background="{StaticResource StandardOrange}" BorderBrush="Black" BorderThickness="5" Width="1030" Height="800" Margin="400,105,645,105">
+                <Grid Background="#80000000" x:Name="DieResultDecisionPopupBackground">
+                    <Grid Background="{StaticResource StandardOrange}" BorderBrush="Black" BorderThickness="5" Width="1030" Height="800" VerticalAlignment="Center" HorizontalAlignment="Center">
                         <TextBlock Name="DieDecisionText" Width="950" Text="Vill du flytta din pjäs till cirkel 1 eller cirkel 6?" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="48" FontFamily="Inconsolata" Margin="10,0,0,0"/>
 
                         <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">

--- a/FiaMedKnuff/GamePage.xaml.cs
+++ b/FiaMedKnuff/GamePage.xaml.cs
@@ -33,6 +33,11 @@ namespace FiaMedKnuff {
             greenTurnIndicator = GreenBorder;
             blueTurnIndicator = BlueBorder;
             DieBtnBorder = dieBtnBorder;
+
+            redSlots = RedSlots;
+            yellowSlots = YellowSlots;
+            greenSlots = GreenSlots;
+            blueSlots = BlueSlots;
             
         }
 
@@ -47,6 +52,10 @@ namespace FiaMedKnuff {
         public static Border greenTurnIndicator;
         public static Border blueTurnIndicator;
 
+        private static StackPanel redSlots;
+        private static StackPanel yellowSlots;
+        private static StackPanel greenSlots;
+        private static StackPanel blueSlots;
 
         /// <summary>
         /// Matches the visual of the die to the result rolled.
@@ -210,5 +219,35 @@ namespace FiaMedKnuff {
             DieResultDecisionPopupBackground.Width = ParentGrid.ActualWidth;
             DieResultDecisionPopupBackground.Height = ParentGrid.ActualHeight;
         }
+
+        /// <summary>
+        /// Updates pawn slots of [team] to show how many pawns of that team have won
+        /// </summary>
+        /// <param name="team">Team</param>
+        public static void UpdatePawnSlots(Team team) {
+            (StackPanel, TeamColor)[] slots = new(StackPanel, TeamColor)[] {
+                (redSlots, TeamColor.Red),
+                (yellowSlots, TeamColor.Yellow),
+                (greenSlots, TeamColor.Green),
+                (blueSlots, TeamColor.Blue),
+                };
+
+            foreach ((StackPanel panel, TeamColor color) in slots) {
+                if (color != team.TeamColor) continue;
+                int count = team.Pawns.Count(p => p.HasWon);
+
+                for(int i = 0; i < count; i++) {
+                    Image image = (Image) panel.Children[i];
+                    switch(color) {
+                        case TeamColor.Red: image.Source = new BitmapImage(new Uri($"ms-appx:///Assets/Pawns/RedPawn.png")); break;
+                        case TeamColor.Yellow: image.Source = new BitmapImage(new Uri($"ms-appx:///Assets/Pawns/YellowPawn.png")); break;
+                        case TeamColor.Green: image.Source = new BitmapImage(new Uri($"ms-appx:///Assets/Pawns/GreenPawn.png")); break;
+                        case TeamColor.Blue: image.Source = new BitmapImage(new Uri($"ms-appx:///Assets/Pawns/BluePawn.png")); break;
+                    }
+                }
+            }
+
+        }
+
     }
 }

--- a/FiaMedKnuff/GamePage.xaml.cs
+++ b/FiaMedKnuff/GamePage.xaml.cs
@@ -96,7 +96,7 @@ namespace FiaMedKnuff {
         /// </summary>
         /// <param name="sender">Starta button</param>
         private void StartaBtn_Click(object sender, RoutedEventArgs e)
-        {            
+        {
             GameManager.Init();
             Frame.Navigate(typeof(GamePage));
         }

--- a/FiaMedKnuff/GamePage.xaml.cs
+++ b/FiaMedKnuff/GamePage.xaml.cs
@@ -203,6 +203,12 @@ namespace FiaMedKnuff {
         {
             NewGameDialog.Width = ParentGrid.ActualWidth;
             NewGameDialog.Height = ParentGrid.ActualHeight;
+
+            RulesPopup.Width = ParentGrid.ActualWidth;
+            RulesPopup.Height = ParentGrid.ActualHeight;
+
+            DieResultDecisionPopupBackground.Width = ParentGrid.ActualWidth;
+            DieResultDecisionPopupBackground.Height = ParentGrid.ActualHeight;
         }
     }
 }

--- a/FiaMedKnuff/MainPage.xaml.cs
+++ b/FiaMedKnuff/MainPage.xaml.cs
@@ -56,7 +56,8 @@ namespace FiaMedKnuff
                
         // Clicking "Starta" navigates the user to the gameboard.
         private void StartaBtn_Click(object sender, RoutedEventArgs e)
-        {                       
+        {
+            GameManager.Init();
             Frame.Navigate(typeof(GamePage));
         }
 

--- a/FiaMedKnuff/ResultatPage.xaml
+++ b/FiaMedKnuff/ResultatPage.xaml
@@ -21,8 +21,8 @@
                 <Border  CornerRadius="35" BorderThickness="5" BorderBrush="Black" Width="300" Height="300">
                     <StackPanel  Background="White" CornerRadius="15">
                         <Image Height="100" Width="100" Source="/Assets/Crown.png" />
-                        <Image Height="100" Width="100"  Source="/Assets/Pawns/RedPawn.png"/>
-                        <TextBlock Text="Röd har vunnit spelet!"
+                        <Image x:Name="PawnImage" Height="100" Width="100"  Source="/Assets/Pawns/RedPawn.png"/>
+                        <TextBlock x:Name="WinningText" Text="Rött lag har vunnit spelet!"
         
                         Foreground="Black"
                          HorizontalAlignment="Center"

--- a/FiaMedKnuff/ResultatPage.xaml.cs
+++ b/FiaMedKnuff/ResultatPage.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using FiaMedKnuff.FiaGame;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -11,6 +12,7 @@ using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Data;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
+using Windows.UI.Xaml.Media.Imaging;
 using Windows.UI.Xaml.Navigation;
 
 // The Blank Page item template is documented at https://go.microsoft.com/fwlink/?LinkId=234238
@@ -22,9 +24,37 @@ namespace FiaMedKnuff
     /// </summary>
     public sealed partial class ResultatPage : Page
     {
+
+        public static TeamColor WinningTeam = TeamColor.None;
+
         public ResultatPage()
         {
             this.InitializeComponent();
+
+            string assetName = "Pawn.png";
+            string name = "No one";
+            switch (WinningTeam) {
+                case TeamColor.Red:
+                    assetName = "RedPawn";
+                    name = "Rött lag";
+                    break;
+                case TeamColor.Yellow:
+                    assetName = "YellowPawn";
+                    name = "Gult lag";
+                    break;
+                case TeamColor.Green:
+                    assetName = "GreenPawn";
+                    name = "Grönt lag";
+                    break;
+                case TeamColor.Blue:
+                    assetName = "BluePawn";
+                    name = "Blått lag";
+                    break;
+            }
+
+            PawnImage.Source = new BitmapImage(new Uri($"ms-appx:///Assets/Pawns/{assetName}.png"));
+            WinningText.Text = $"{name} har vunnit spelet!";
+
         }
 
         private void Button_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Changes:
- Pawns entering the center will now be removed and will be counted has "having won"
- When all pawns in a team have won, that team wins and the user is sent to the results view
- The slots on the side of the board fill up depending on how many pawns have won

Based on #30, which should be merged first.