### PR TITLE
Pawn moving conditions, turn skip and cheat menu

### DIFF
--- a/FiaMedKnuff/FiaGame/Game.cs
+++ b/FiaMedKnuff/FiaGame/Game.cs
@@ -129,6 +129,8 @@ namespace FiaMedKnuff.FiaGame {
             GamePage.ChangeOutputTextBox($"Det är " + CurrentTeam.Name + "s tur att rulla tärningen!");
             CurrentGameState = GameState.PreRoll;
 
+            Trace.WriteLine($"{GetTeamColorString(CurrentTeam.TeamColor)} is starting their turn.");
+
             var border = GetTeamColorBorder(CurrentTeam.TeamColor);
             border.BorderBrush = (SolidColorBrush)App.Current.Resources[GetTeamColorString(CurrentTeam.TeamColor)];
         }

--- a/FiaMedKnuff/FiaGame/GameEvents.cs
+++ b/FiaMedKnuff/FiaGame/GameEvents.cs
@@ -21,6 +21,7 @@ namespace FiaMedKnuff.FiaGame {
             if (GameManager.CurrentGame.CurrentGameState == Game.GameState.PostRoll)
             {
                 if (tile.Stander == null) return;
+                if (!tile.Stander.CanMove()) return;
                                 
                 if (GameManager.CurrentGame.CurrentTeam != tile.Stander.Team) return;
                 Trace.WriteLine($"Boop! You have clicked tile with space {tile.Space}!");
@@ -73,9 +74,17 @@ namespace FiaMedKnuff.FiaGame {
 
             GameManager.CurrentDieNumber = dieThrow;
 
-            // Set all to be selectable and change to PostRoll
-            TileControl.Selectable = true;
-            GameManager.CurrentGame.CurrentGameState = Game.GameState.PostRoll;
+            if (GameManager.CurrentGame.CurrentTeam.CanMoveCheck()) {
+                // Set all to be selectable and change to PostRoll
+                TileControl.Selectable = true;
+                GameManager.CurrentGame.CurrentGameState = Game.GameState.PostRoll;
+            } else {
+                // Skip turn
+
+                GameManager.CurrentGame.EndTurn();
+            }
+
+            
             return dieThrow;
 
 

--- a/FiaMedKnuff/FiaGame/GameEvents.cs
+++ b/FiaMedKnuff/FiaGame/GameEvents.cs
@@ -53,14 +53,15 @@ namespace FiaMedKnuff.FiaGame {
 
         public static List<int> ForcedRolls = new List<int>();
 
-        public static int OnDieClicked() {
+        public static async Task OnDieClicked() {
 
             GamePage.EndGlowEffectDie();
 
             // Return if state is PostRoll
             if (GameManager.CurrentGame.CurrentGameState == Game.GameState.PostRoll) {
                 GamePage.changeOutputText.Text = "Det är inte din tur.";
-                return -1;
+                GamePage.SetDie(-1);
+                return;
             }
             
             // Roll and set die number
@@ -73,6 +74,7 @@ namespace FiaMedKnuff.FiaGame {
             }
 
             GameManager.CurrentDieNumber = dieThrow;
+            GamePage.SetDie(dieThrow);
 
             if (GameManager.CurrentGame.CurrentTeam.CanMoveCheck()) {
                 // Set all to be selectable and change to PostRoll
@@ -80,12 +82,12 @@ namespace FiaMedKnuff.FiaGame {
                 GameManager.CurrentGame.CurrentGameState = Game.GameState.PostRoll;
             } else {
                 // Skip turn
-
+                GamePage.ChangeOutputTextBox($"{ GameManager.CurrentGame.CurrentTeam.Name} blev tvungen att stå över.");
+                await Task.Delay(1500);
                 GameManager.CurrentGame.EndTurn();
             }
 
-            
-            return dieThrow;
+            return;
 
 
         }

--- a/FiaMedKnuff/FiaGame/GameEvents.cs
+++ b/FiaMedKnuff/FiaGame/GameEvents.cs
@@ -50,6 +50,8 @@ namespace FiaMedKnuff.FiaGame {
             }           
         }
 
+        public static List<int> ForcedRolls = new List<int>();
+
         public static int OnDieClicked() {
 
             GamePage.EndGlowEffectDie();
@@ -63,6 +65,11 @@ namespace FiaMedKnuff.FiaGame {
             // Roll and set die number
             Random rnd = new Random();
             int dieThrow = rnd.Next(1, 7);
+
+            if (ForcedRolls.Count != 0) {
+                dieThrow = ForcedRolls[0];
+                GamePage.UpdateRollsCheatBox();
+            }
 
             GameManager.CurrentDieNumber = dieThrow;
 

--- a/FiaMedKnuff/FiaGame/GameEvents.cs
+++ b/FiaMedKnuff/FiaGame/GameEvents.cs
@@ -83,7 +83,7 @@ namespace FiaMedKnuff.FiaGame {
             } else {
                 // Skip turn
                 GamePage.ChangeOutputTextBox($"{ GameManager.CurrentGame.CurrentTeam.Name} blev tvungen att stå över.");
-                await Task.Delay(1500);
+                await Task.Delay(1400);
                 GameManager.CurrentGame.EndTurn();
             }
 

--- a/FiaMedKnuff/FiaGame/Pawn.cs
+++ b/FiaMedKnuff/FiaGame/Pawn.cs
@@ -162,18 +162,22 @@ namespace FiaMedKnuff.FiaGame {
         public bool CanMove() {
             if (CurrentTile.SpaceType == SpaceType.Home) {
                 if(GameManager.CurrentDieNumber != 1 && GameManager.CurrentDieNumber != 6) {
+                    Trace.WriteLine("Can't move due to die not being 1 or 6.");
                     return false;
                 }
 
                 Tile startTile = Team.Path[0]; // Previously: GameManager.CurrentGame.Tiles[SpaceType.Surrounding][Team.StartingSpace]
-                if (GameManager.CurrentDieNumber == 1 && startTile.Stander.Team == Team) {
+                if (GameManager.CurrentDieNumber == 1 && startTile.Stander?.Team == Team) {
+                    Trace.WriteLine("Can't move due to busy starting space.");
                     return false;
                 }
             }
             Tile nextTile = Team.Path[Math.Clamp(SpaceInPath + 1, 0, Team.Path.Count - 1)];
-            if (nextTile.Stander.Team == Team) {
+            if (nextTile.Stander?.Team == Team) {
+                Trace.WriteLine("Can't move due to busy front space.");
                 return false;
             }
+            Trace.WriteLine("Can move!");
             return true;
         }
      }

--- a/FiaMedKnuff/FiaGame/Pawn.cs
+++ b/FiaMedKnuff/FiaGame/Pawn.cs
@@ -154,5 +154,27 @@ namespace FiaMedKnuff.FiaGame {
 
             Team.WinCheck();
         }
+
+        /// <summary>
+        /// Returns whether it is possible for this pawn to move
+        /// </summary>
+        /// <returns></returns>
+        public bool CanMove() {
+            if (CurrentTile.SpaceType == SpaceType.Home) {
+                if(GameManager.CurrentDieNumber != 1 && GameManager.CurrentDieNumber != 6) {
+                    return false;
+                }
+
+                Tile startTile = Team.Path[0]; // Previously: GameManager.CurrentGame.Tiles[SpaceType.Surrounding][Team.StartingSpace]
+                if (GameManager.CurrentDieNumber == 1 && startTile.Stander.Team == Team) {
+                    return false;
+                }
+            }
+            Tile nextTile = Team.Path[Math.Clamp(SpaceInPath + 1, 0, Team.Path.Count - 1)];
+            if (nextTile.Stander.Team == Team) {
+                return false;
+            }
+            return true;
+        }
      }
 }

--- a/FiaMedKnuff/FiaGame/Pawn.cs
+++ b/FiaMedKnuff/FiaGame/Pawn.cs
@@ -177,7 +177,17 @@ namespace FiaMedKnuff.FiaGame {
                 Trace.WriteLine("Can't move due to busy front space.");
                 return false;
             }
-            Trace.WriteLine("Can move!");
+
+            if (SpaceInPath + GameManager.CurrentDieNumber > Team.Path.Count - 1) {
+                var count = Team.Path.Count - 1;
+                var newSpace = count - (SpaceInPath + GameManager.CurrentDieNumber) % count;
+                if (Team.Path[newSpace].Stander?.Team == Team) {
+                    Trace.WriteLine($"Can't move due to teammate on pushback tile.");
+                    return false;
+                }
+            }
+
+                Trace.WriteLine("Can move!");
             return true;
         }
      }

--- a/FiaMedKnuff/FiaGame/Team.cs
+++ b/FiaMedKnuff/FiaGame/Team.cs
@@ -71,5 +71,16 @@ namespace FiaMedKnuff.FiaGame {
             navigationFrame.Navigate(typeof(ResultatPage));
 
         }
+
+
+        /// <summary>
+        /// Returns true if any pawn in the team can move
+        /// </summary>
+        public bool CanMoveCheck() {
+            if (Pawns.All(pawn => !pawn.CanMove())) {
+                return false;
+            }
+            return true;
+        }
     }
 }

--- a/FiaMedKnuff/GamePage.xaml
+++ b/FiaMedKnuff/GamePage.xaml
@@ -342,8 +342,15 @@
                 </StackPanel>
             </Grid>
 
-            <StackPanel>
-                <Button Width="200" Height="70" Content="Nytt Spel" Background="{StaticResource OrangeButton}" BorderBrush="Black" BorderThickness="5" CornerRadius="15" FontSize="30" FontFamily="Inconsolata" HorizontalAlignment="Left" Margin="10,10,0,0" Click="NyttSpelBtn_Click" Style="{StaticResource ButtonStyleFixOrangeGlobal}" Foreground="{StaticResource StandardText}"/>
+            <StackPanel HorizontalAlignment="Left" VerticalAlignment="Top">
+                <Button Width="200" Height="70" Content="Nytt Spel" Background="{StaticResource OrangeButton}" BorderBrush="Black" BorderThickness="5" CornerRadius="15" FontSize="30" FontFamily="Inconsolata" Margin="10,10,0,0" Click="NyttSpelBtn_Click" Style="{StaticResource ButtonStyleFixOrangeGlobal}" Foreground="{StaticResource StandardText}"/>
+                <Border BorderThickness="5" BorderBrush="Black" Height="300" Width="200" Margin="10" CornerRadius="20" x:Name="CheatPanel" Visibility="Collapsed">
+                    <StackPanel Orientation="Vertical" Background="LightSalmon" >
+                        <TextBlock FontSize="20" HorizontalAlignment="Center">Cheat Menu 2000</TextBlock>
+                        <TextBlock>Force next die rolls:</TextBlock>
+                        <TextBox Name="RollsCheatBox" TextChanged="RollsCheatBox_TextChanged"></TextBox>
+                    </StackPanel>
+                </Border>
             </StackPanel>
             <StackPanel HorizontalAlignment="Right" VerticalAlignment="Top" Margin="10">
                 <Button Opacity="0.5" Name="SettingsBtn" Width="75" Height="75" Background="White" BorderBrush="Black" BorderThickness="5" CornerRadius="15" Margin="0,0,0,10" Click="SettingsBtn_Click" Style="{StaticResource ButtonStyleFixWhiteGlobal}">
@@ -396,7 +403,7 @@
                 <ScrollViewer VerticalScrollBarVisibility="Visible" HorizontalScrollBarVisibility="Disabled">
                     <TextBlock Name="RulesText" Text="Rules Text" TextWrapping="Wrap" HorizontalAlignment="Left" VerticalAlignment="Top" FontSize="28" FontFamily="Inconsolata" Margin="10,60,0,0" Foreground="{StaticResource StandardText}"/>
                 </ScrollViewer>
-                <Button Name="RulesCloseBtn" Width="70" Height="70" HorizontalAlignment="Right" VerticalAlignment="Top" Content="x" Foreground="Red" Background="{StaticResource WhiteButton}" BorderBrush="Black" BorderThickness="5" CornerRadius="15" FontSize="50" Padding="0,0,2,0" FontFamily="Inconsolata" Margin="0,10,10,0" Click="CloseBtn_Click" Style="{StaticResource ButtonStyleFixWhiteGlobal}"/>
+                <Button RightTapped="RulesCloseBtn_RightTapped" Name="RulesCloseBtn" Width="70" Height="70" HorizontalAlignment="Right" VerticalAlignment="Top" Content="x" Foreground="Red" Background="{StaticResource WhiteButton}" BorderBrush="Black" BorderThickness="5" CornerRadius="15" FontSize="50" Padding="0,0,2,0" FontFamily="Inconsolata" Margin="0,10,10,0" Click="CloseBtn_Click" Style="{StaticResource ButtonStyleFixWhiteGlobal}"/>
             </Grid>
         </Grid>
 

--- a/FiaMedKnuff/GamePage.xaml.cs
+++ b/FiaMedKnuff/GamePage.xaml.cs
@@ -38,6 +38,8 @@ namespace FiaMedKnuff {
             yellowSlots = YellowSlots;
             greenSlots = GreenSlots;
             blueSlots = BlueSlots;
+
+            rollsCheatBox = RollsCheatBox;
             
         }
 
@@ -56,6 +58,8 @@ namespace FiaMedKnuff {
         private static StackPanel yellowSlots;
         private static StackPanel greenSlots;
         private static StackPanel blueSlots;
+
+        private static TextBox rollsCheatBox;
 
         /// <summary>
         /// Matches the visual of the die to the result rolled.
@@ -249,5 +253,31 @@ namespace FiaMedKnuff {
 
         }
 
+        private void RollsCheatBox_TextChanged(object sender, TextChangedEventArgs e) {
+            TextBox box = (TextBox)sender;
+            var input = box.Text;
+            foreach(char c in input) {
+                if ((c < '0' || c > '9') && c != ' ') return;
+            }
+            var array = input.Split(new[] { " " }, StringSplitOptions.RemoveEmptyEntries);
+            int[] ints = Array.ConvertAll(array, s => int.Parse(s));
+
+            Trace.WriteLine(string.Join("-", ints));
+            GameEvents.ForcedRolls = ints.ToList();
+
+        }
+
+        public static void UpdateRollsCheatBox() {
+            int i = 0;
+            foreach(char c in rollsCheatBox.Text) {
+                i++;
+                if (c == ' ') break;
+            }
+            rollsCheatBox.Text = rollsCheatBox.Text.Remove(0, i);
+        }
+
+        private void RulesCloseBtn_RightTapped(object sender, RightTappedRoutedEventArgs e) {
+            CheatPanel.Visibility = CheatPanel.Visibility == Visibility ? Visibility.Collapsed : Visibility.Visible;
+        }
     }
 }

--- a/FiaMedKnuff/GamePage.xaml.cs
+++ b/FiaMedKnuff/GamePage.xaml.cs
@@ -40,6 +40,8 @@ namespace FiaMedKnuff {
             blueSlots = BlueSlots;
 
             rollsCheatBox = RollsCheatBox;
+
+            dieButton = DieButton;
             
         }
 
@@ -61,21 +63,29 @@ namespace FiaMedKnuff {
 
         private static TextBox rollsCheatBox;
 
+        public static bool DieIsRollable = true;
+
+        private static Button dieButton;
+
         /// <summary>
         /// Matches the visual of the die to the result rolled.
         /// </summary>
-        private void DieButton_Click(object sender, RoutedEventArgs e)
-        {           
-            int dieThrow = GameEvents.OnDieClicked();
+        private async void DieButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (!DieIsRollable) return;
 
+            await GameEvents.OnDieClicked();
+
+        }
+
+        public static void SetDie(int dieThrow) {
             if (dieThrow != -1) {
                 // Sets the image of the die to match the result rolled.
                 GamePage.changeOutputText.Text = $"Du rullade en {dieThrow}:a!";
                 ImageBrush img = new ImageBrush();
                 img.ImageSource = new BitmapImage(new Uri($@"ms-appx:///Assets/Die/Die{dieThrow}.png"));
-                DieButton.Background = img;
+                dieButton.Background = img;
             }
-
         }
               
         /// <summary>


### PR DESCRIPTION
- A cheat menu which is toggled by right clicking on the X button of the rules dialog.
- Turns will now be skipped if there are no possible movements. There is also a message and a delay.
- Added CanMove() to Pawn which returns false in these conditions:
   - The pawn is at home and has not rolled a 1 or 6.
   - The pawn is at home, has rolled a 1 and the starting spot is taken by another teammate.
   - A teammate is on the space in front of the pawn.
   - If the roll value goes beyond the center and if the spot the pawn would otherwise land on is taken by another teammate (pushback).

Bug: There is no condition for rolling a 6 from home and choosing to stand on 1 or 6, which means this will still result in a teammate being shoved.
